### PR TITLE
Fix note box display issue

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -567,7 +567,7 @@ module.exports = function () {
 };
 ```
 
-:::info
+<Note>
 
 The `historyApiFallback: true` above combined with the `publicPath: "/"` from the webpack.config.js file shall, if we have router defined in our app, enable page refresh on the flight. Otherwise, a 404 error on sub-router page refresh will occur[^enabling-routed-page-refresh-with-webpack].
 
@@ -575,7 +575,7 @@ Please checkout [Server-side rendering vs Client-side rendering][Server-side ren
 
 Finally, here is our Node.js API file:
 
-:::
+</Note>
 
 ```javascript
 "use strict";


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

The info admonition box (`:::info`) is not rendered because the site does not support Docusaurus syntax

<img width="894" alt="page 2" src="https://user-images.githubusercontent.com/16126939/233758705-98440643-b41a-4235-9e26-bb42af55a9e5.png">

- Changed the syntax to supported version.

### Security


Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
