### PR TITLE
Use yarn instead of npm

### DIFF
--- a/src/content/learn/start-a-new-react-project.md
+++ b/src/content/learn/start-a-new-react-project.md
@@ -223,7 +223,7 @@ To install Babel in our project, go ahead and run
 
 <TerminalBlock>
 
-npm install --save-dev @babel/core @babel/cli @babel/preset-env @babel/preset-react
+yarn add -D @babel/core @babel/cli @babel/preset-env @babel/preset-react
 
 </TerminalBlock>
 
@@ -250,7 +250,7 @@ Now we need to acquire now and configure [Webpack][webpack] (later). We'll need 
 
 <TerminalBlock>
 
-npm install --save-dev webpack webpack-cli webpack-dev-server style-loader css-loader babel-loader
+yarn add -D webpack webpack-cli webpack-dev-server style-loader css-loader babel-loader
 
 </TerminalBlock>
 
@@ -259,7 +259,7 @@ npm install --save-dev webpack webpack-cli webpack-dev-server style-loader css-l
 We'll need to get two more packages:
 
 ```bash
-npm install react react-dom
+yarn add react react-dom
 ```
 
 Note that we do save those as _regular_ dependencies, i.e. without `--save-dev` option.
@@ -272,7 +272,7 @@ We integrate TypeScript by
 
 <TerminalBlock>
 
-npm install --save-dev typescript
+yarn add -D typescript
 
 </TerminalBlock>
 
@@ -303,7 +303,7 @@ I guess we don't need to explain why we need to setup some testing here, so let'
 
 <TerminalBlock>
 
-npm install --save-dev jest babel-jest @types/jest ts-jest react-test-renderer @testing-library/react @testing-library/jest-dom
+yarn add -D jest babel-jest @types/jest ts-jest react-test-renderer @testing-library/react @testing-library/jest-dom
 
 </TerminalBlock>
 
@@ -324,7 +324,7 @@ Jest supports TypeScript, via [Babel][Babel]. First, make sure we followed the i
 
 <TerminalBlock>
 
-npm install --save-dev @babel/preset-typescript
+yarn add -D @babel/preset-typescript
 
 </TerminalBlock>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Changelog
---------

### Added

### Changed

- Changed instruction on installing packages to using `yarn` instead of `npm`

### Deprecated

### Removed

### Fixed

### Security


Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
