### PR TITLE
Add usage example for Fragments

### DIFF
--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -208,3 +208,41 @@ function PostBody({ body }) {
 ```
 
 </Sandpack>
+
+### Conditional Rendering
+
+When we do conditional rendering using, for example, the following TypeScript code
+
+```js
+export default function MyComponent(props: MyComponentProps): JSX.Element {
+  return (
+      ( props.shouldRender && (
+      <StyledButton onClick={() => ...}>
+        <ButtonIcon />
+      </StyledDeleteButton>
+      ) )
+  );
+}
+```
+
+We will see the following compiler error:
+
+```bash
+Type 'Element | undefined' is not assignable to type 'ReactElement<any, string | ((props: any)
+```
+
+In this case we need to [wrap the return in Fragments](https://stackoverflow.com/a/75130652):
+
+```js {3,9}
+export default function DeleteButton(props: DeleteButtonProps): JSX.Element {
+  return (
+    <>
+      ( props.graphId && (
+      <StyledDeleteButton onClick={() => props.onClick(props.graphId)}>
+        <TrashIcon data-testid="deleteButton" />
+      </StyledDeleteButton>
+      ) )
+    </>
+  );
+}
+```

--- a/src/content/reference/react/Fragment.md
+++ b/src/content/reference/react/Fragment.md
@@ -209,7 +209,7 @@ function PostBody({ body }) {
 
 </Sandpack>
 
-### Conditional Rendering
+### Conditional Rendering {/*conditional-rendering*/}
 
 When we do conditional rendering using, for example, the following TypeScript code
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/react.dev/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

Changelog
---------

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security


Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation

Reference
---------

- [Type 'Element | undefined' is not assignable to type 'ReactElement<any, string | ((props: any)](https://stackoverflow.com/a/75130652)